### PR TITLE
Broken list of middlewares

### DIFF
--- a/sentry_dramatiq/__init__.py
+++ b/sentry_dramatiq/__init__.py
@@ -43,7 +43,7 @@ def _patch_dramatiq_broker():
             # RedisBroker does not.
             if len(args) > 0:
                 assert len(args) < 2
-                middleware = None if args[0] is None else [args[0]]
+                middleware = None if args[0] is None else args[0]
                 args = []
             else:
                 middleware = None

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,9 @@ envlist =
     # === Dramatiq 1.4 ===
     {py35,py36,py37,py38}-dramatiq-1.4
 
+    # === Dramatiq 1.7 ===
+    {py35,py36,py37,py38}-dramatiq-1.7
+
     # === Dramatiq dev ===
     {py35,py36,py37,py38}-dramatiq-dev
 
@@ -23,6 +26,7 @@ deps =
     .[test]
     dramatiq-1.3: dramatiq>=1.3,<1.4
     dramatiq-1.4: dramatiq>=1.4,<1.5
+    dramatiq-1.7: dramatiq>=1.7,<1.8
     dramatiq-dev: git+https://github.com/Bogdanp/dramatiq#egg=dramatiq
 
 [testenv:lint]


### PR DESCRIPTION
## Problem

Somehow the broker init patch is inserting a list inside the list of middlewares, causing the `add_middleware` function to fail, when using the StubBroker.

```
    django_1    |     broker = broker_class(middleware=middleware, **broker_options)
    django_1    |   File "/usr/lib/python3.6/site-packages/dramatiq/brokers/stub.py", line 33, in __init__
    django_1    |     super().__init__(middleware)
    django_1    |   File "/usr/lib/python3.6/site-packages/sentry_dramatiq/__init__.py", line 63, in sentry_patched_broker__init__
    django_1    |     original_broker__init__(self, *args, **kw)
    django_1    |   File "/usr/lib/python3.6/site-packages/dramatiq/broker.py", line 84, in __init__
    django_1    |     self.add_middleware(m)
    django_1    |   File "/usr/lib/python3.6/site-packages/dramatiq/broker.py", line 135, in add_middleware
    django_1    |     self.actor_options |= middleware.actor_options
    django_1    | AttributeError: 'list' object has no attribute 'actor_options'
```

## Fix

When brokers were sending `middleware` as args, we were creating a `list` of `list` of middlewares, instead than a `list` of middlewares:

![image](https://user-images.githubusercontent.com/5559120/66146123-877d0d80-e5e2-11e9-9433-493a0f9af976.png)