### PR TITLE
Ensure task scope doesn't inherit breadcrumbs

### DIFF
--- a/sentry_dramatiq/__init__.py
+++ b/sentry_dramatiq/__init__.py
@@ -83,6 +83,7 @@ class SentryMiddleware(Middleware):
         message._scope_manager.__enter__()
 
         with hub.configure_scope() as scope:
+            scope.clear_breadcrumbs()
             scope.transaction = message.actor_name
             scope.set_tag('dramatiq_message_id', message.message_id)
             scope.add_event_processor(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import subprocess
 
@@ -190,6 +191,7 @@ def broker(sentry_init):
     sentry_init(integrations=[DramatiqIntegration()])
     broker = StubBroker()
     broker.emit_after("process_boot")
+    logging.error('BREADCRUMB')  # Collected as breadcrumb out of task scope.
     dramatiq.set_broker(broker)
     yield broker
     broker.flush_all()


### PR DESCRIPTION
During process startup, several things may get logged (for example by
imports) and subsequently get collected by sentry as breadcrumbs.
Since breadcrumbs are inherited in nested scopes, any task that raises a
sentry error will include breadcrumbs since the process started.

This commit ensures that each task's sentry scope is started without any
preexisting breadcrumbs. It adds a test that fails without the change
that clears the scope's breadcrumbs.

Related issue & PR in sentry's SDK:
- https://github.com/getsentry/sentry-python/issues/207
- https://github.com/getsentry/sentry-python/pull/297