### PR TITLE
Ignore expected exceptions

### DIFF
--- a/sentry_dramatiq/__init__.py
+++ b/sentry_dramatiq/__init__.py
@@ -96,8 +96,12 @@ class SentryMiddleware(Middleware):
         if integration is None:
             return
 
+        actor = broker.get_actor(message.actor_name)
+
         try:
-            if exception is not None:
+            if exception is not None and not (
+                actor.throws and isinstance(exception, actor.throws)
+            ):
                 event, hint = event_from_exception(
                     exception,
                     client_options=hub.client.options,

--- a/sentry_dramatiq/__init__.py
+++ b/sentry_dramatiq/__init__.py
@@ -97,10 +97,11 @@ class SentryMiddleware(Middleware):
             return
 
         actor = broker.get_actor(message.actor_name)
+        throws = message.options.get("throws") or actor.options.get("throws")
 
         try:
             if exception is not None and not (
-                actor.throws and isinstance(exception, actor.throws)
+                throws and isinstance(exception, throws)
             ):
                 event, hint = event_from_exception(
                     exception,

--- a/sentry_dramatiq/__init__.py
+++ b/sentry_dramatiq/__init__.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Dict, Optional, Union
 from dramatiq.broker import Broker
 from dramatiq.message import Message
 from dramatiq.middleware import Middleware, default_middleware
+from dramatiq.errors import Retry
 from sentry_sdk import Hub
 from sentry_sdk.integrations import Integration
 from sentry_sdk.utils import (
@@ -102,7 +103,7 @@ class SentryMiddleware(Middleware):
         try:
             if exception is not None and not (
                 throws and isinstance(exception, throws)
-            ):
+            ) and not isinstance(exception, Retry):
                 event, hint = event_from_exception(
                     exception,
                     client_options=hub.client.options,

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -201,3 +201,18 @@ def test_that_expected_exceptions_are_not_captured(broker, worker,
     worker.join()
 
     assert events == []
+
+
+def test_that_retry_exceptions_are_not_captured(broker, worker,
+                                               capture_events):
+    events = capture_events()
+
+    @dramatiq.actor(max_retries=2)
+    def dummy_actor():
+        raise dramatiq.errors.Retry('Retrying', delay=100)
+
+    dummy_actor.send()
+    broker.join(dummy_actor.queue_name)
+    worker.join()
+
+    assert events == []


### PR DESCRIPTION
Hi,
this is complementary to a PR I opened to dramatiq https://github.com/Bogdanp/dramatiq/pull/303 making the required changes in order to ignore exceptions that are part of the expected exceptions declared for an actor using a `throws` argument. 

This depends on my dramatiq PR so untill it gets reviewed, merged and released I open this as a draft