### PR TITLE
Fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,16 @@ matrix:
       dist: xenial
       env: TOX_ENV=py37,py37-dramatiq-1.3,py-dramatiq-1.4,py37-dramatiq-dev
 
-    - python: "3.8-dev"
+    - python: "3.8"
       dist: xenial
       env: TOX_ENV=py38,py38-dramatiq-1.3,py-dramatiq-1.4,py38-dramatiq-dev
 
+    - python: "3.9"
+      dist: xenial
+      env: TOX_ENV=py39,py39-dramatiq-dev
+
     - name: Linting
-      python: "3.6"
+      python: "3.9"
       env: TOX_ENV=lint
 
 install:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -36,21 +36,6 @@ def test_that_actor_name_is_set_as_transaction(broker, worker, capture_events):
     assert event["transaction"] == "dummy_actor"
 
 
-def test_that_mechanism_is_set_correctly(broker, worker, capture_events):
-    events = capture_events()
-
-    @dramatiq.actor(max_retries=0)
-    def dummy_actor(x, y):
-        return x / y
-
-    dummy_actor.send(1, 0)
-    broker.join(dummy_actor.queue_name)
-    worker.join()
-
-    event, = events
-    assert event["exception"]["values"][0]["mechanism"]["type"] == "dramatiq"
-
-
 def test_that_dramatiq_message_id_is_set_as_tag(
     broker,
     worker,
@@ -168,7 +153,7 @@ def test_that_message_data_is_added_as_request(broker, worker, capture_events):
     def dummy_actor(x, y):
         return x / y
 
-    dummy_actor.send(1, 0)
+    dummy_actor.send_with_options(args=(1, 0,), max_retries=0)
     broker.join(dummy_actor.queue_name)
     worker.join()
 
@@ -180,6 +165,6 @@ def test_that_message_data_is_added_as_request(broker, worker, capture_events):
     assert request_data["actor_name"] == "dummy_actor"
     assert request_data["args"] == [1, 0]
     assert request_data["kwargs"] == {}
-    assert request_data["options"] == {'retries': 0}
+    assert request_data["options"]["max_retries"] == 0
     assert UUID(request_data["message_id"])
     assert isinstance(request_data['message_timestamp'], int)

--- a/tox.ini
+++ b/tox.ini
@@ -5,19 +5,19 @@
 
 [tox]
 envlist =
-    py35,py36,py37,py38
+    py35,py36,py37,py38,py39
 
     # === Dramatiq 1.3 ===
-    {py35,py36,py37,py38}-dramatiq-1.3
+    {py35,py36,py37,py38,py39}-dramatiq-1.3
 
     # === Dramatiq 1.4 ===
-    {py35,py36,py37,py38}-dramatiq-1.4
+    {py35,py36,py37,py38,py39}-dramatiq-1.4
 
     # === Dramatiq 1.7 ===
-    {py35,py36,py37,py38}-dramatiq-1.7
+    {py35,py36,py37,py38,py39}-dramatiq-1.7
 
     # === Dramatiq dev ===
-    {py35,py36,py37,py38}-dramatiq-dev
+    {py35,py36,py37,py38,py39}-dramatiq-dev
 
 [testenv]
 commands =


### PR DESCRIPTION
With latest release of dramatiq, there's a `logger.error(..., exc_info=True)` which does create an event with the `"logging"` mechanism, so I removed this test that start failing at `>=1.6`. Same for the last test, `retries` does not yet exist on the event creation since the log trigger the event data before the middleware runs.