### PR TITLE
Add throws and retry & bump to 0.3.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /*.egg-info
 *.sublime-*
 *.pyc
+.python-version

--- a/sentry_dramatiq/__init__.py
+++ b/sentry_dramatiq/__init__.py
@@ -10,7 +10,7 @@ from sentry_sdk.integrations import Integration
 from sentry_sdk.utils import (
     AnnotatedValue,
     capture_internal_exceptions,
-    event_from_exception
+    event_from_exception,
 )
 
 
@@ -37,7 +37,7 @@ def _patch_dramatiq_broker():
         integration = hub.get_integration(DramatiqIntegration)
 
         try:
-            middleware = kw.pop('middleware')
+            middleware = kw.pop("middleware")
         except KeyError:
             # Unfortunately Broker and StubBroker allows middleware to be
             # passed in as positional arguments, whilst RabbitmqBroker and
@@ -55,11 +55,12 @@ def _patch_dramatiq_broker():
             middleware = list(middleware)
 
         if integration is not None:
-            assert SentryMiddleware not in (m.__class__ for m in middleware),\
-                "Sentry middleware must not be passed in manually to broker"
+            assert SentryMiddleware not in (
+                m.__class__ for m in middleware
+            ), "Sentry middleware must not be passed in manually to broker"
             middleware.insert(0, SentryMiddleware())
 
-        kw['middleware'] = middleware
+        kw["middleware"] = middleware
         # raise Exception([args, kw])
         original_broker__init__(self, *args, **kw)
 
@@ -85,7 +86,7 @@ class SentryMiddleware(Middleware):
 
         with hub.configure_scope() as scope:
             scope.transaction = message.actor_name
-            scope.set_tag('dramatiq_message_id', message.message_id)
+            scope.set_tag("dramatiq_message_id", message.message_id)
             scope.add_event_processor(
                 _make_message_event_processor(message, integration)
             )
@@ -101,9 +102,11 @@ class SentryMiddleware(Middleware):
         throws = message.options.get("throws") or actor.options.get("throws")
 
         try:
-            if exception is not None and not (
-                throws and isinstance(exception, throws)
-            ) and not isinstance(exception, Retry):
+            if (
+                exception is not None
+                and not (throws and isinstance(exception, throws))
+                and not isinstance(exception, Retry)
+            ):
                 event, hint = event_from_exception(
                     exception,
                     client_options=hub.client.options,
@@ -147,13 +150,13 @@ class DramatiqMessageExtractor(object):
         content_length = self.content_length()
         contexts = event.setdefault("contexts", {})
         request_info = contexts.setdefault("dramatiq", {})
-        request_info['type'] = "dramatiq"
+        request_info["type"] = "dramatiq"
 
         bodies = client.options["request_bodies"]
         if (
             bodies == "never"
-            or (bodies == "small" and content_length > 10 ** 3)
-            or (bodies == "medium" and content_length > 10 ** 4)
+            or (bodies == "small" and content_length > 10**3)
+            or (bodies == "medium" and content_length > 10**4)
         ):
             data = AnnotatedValue(
                 "",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md') as f:
 
 setup_kwargs = dict(
     name='sentry_dramatiq',
-    version='0.3.2',
+    version='0.3.3',
     description='Dramatiq task processor integration for the Sentry SDK',
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -16,7 +16,7 @@ setup_kwargs = dict(
     license='BSD',
     platforms='any',
     install_requires=[
-        'dramatiq',
+        'dramatiq>=1.9',
         'sentry_sdk',
     ],
     extras_require={
@@ -25,6 +25,7 @@ setup_kwargs = dict(
             'flake8',
             'isort',
             'pytest',
+            'black',
         },
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -1,45 +1,45 @@
 from setuptools import setup
 
-with open('README.md') as f:
+with open("README.md") as f:
     long_description = f.read()
 
 setup_kwargs = dict(
-    name='sentry_dramatiq',
-    version='0.3.3',
-    description='Dramatiq task processor integration for the Sentry SDK',
+    name="sentry_dramatiq",
+    version="0.3.3",
+    description="Dramatiq task processor integration for the Sentry SDK",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    packages=['sentry_dramatiq'],
-    author='Jacob Magnusson',
-    author_email='m@jacobian.se',
-    url='https://github.com/jmagnusson/sentry-dramatiq',
-    license='BSD',
-    platforms='any',
+    long_description_content_type="text/markdown",
+    packages=["sentry_dramatiq"],
+    author="Jacob Magnusson",
+    author_email="m@jacobian.se",
+    url="https://github.com/jmagnusson/sentry-dramatiq",
+    license="BSD",
+    platforms="any",
     install_requires=[
-        'dramatiq>=1.9',
-        'sentry_sdk',
+        "dramatiq>=1.9",
+        "sentry_sdk",
     ],
     extras_require={
-        'test': {
-            'coverage',
-            'flake8',
-            'isort',
-            'pytest',
-            'black',
+        "test": {
+            "coverage",
+            "flake8",
+            "isort",
+            "pytest",
+            "black",
         },
     },
     classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
 )
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     setup(**setup_kwargs)

--- a/tox.ini
+++ b/tox.ini
@@ -5,23 +5,26 @@
 
 [tox]
 envlist =
-    py35,py36,py37,py38,py39
+    py35,py36,py37,py38,py39,py310,py311
 
-    # === Dramatiq 1.3 ===
-    {py35,py36,py37,py38,py39}-dramatiq-1.3
+    # === Dramatiq 1.9 ===
+    {py35,py36,py37,py38}-dramatiq-1.9
 
-    # === Dramatiq 1.4 ===
-    {py35,py36,py37,py38,py39}-dramatiq-1.4
+    # === Dramatiq 1.11 ===
+    {py35,py36,py37,py38,py39,py310}-dramatiq-1.11
 
-    # === Dramatiq 1.7 ===
-    {py35,py36,py37,py38,py39}-dramatiq-1.7
+    # === Dramatiq 1.13 ===
+    {py36,py37,py38,py39,py310}-dramatiq-1.13
+
+    # === Dramatiq 1.14 ===
+    {py37,py38,py39,py310,py311}-dramatiq-1.14
 
     # === Dramatiq dev ===
-    {py35,py36,py37,py38,py39}-dramatiq-dev
+    {py37,py38,py39,py310,py311}-dramatiq-dev
 
 [testenv]
 commands =
-    coverage run --source=sentry_dramatiq -m py.test
+    coverage run --source=sentry_dramatiq -m pytest
 deps =
     .[test]
     dramatiq-1.3: dramatiq>=1.3,<1.4


### PR DESCRIPTION
This PR is Based on: https://github.com/jacobsvante/sentry-dramatiq/pull/11

Starting from dramatiq 1.9 `Retry` exception and exceptions defined in throws argument are ignored. See https://github.com/Bogdanp/dramatiq/commit/76525adff23c906a5c532176c92b59bf7023e195
So these exceptions shouldn't be sent to sentry as well

Also applied `black` formatting and set `dramatiq>=1.9`
