### PR TITLE
Add Github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,38 @@
+name: sentry-dramatiq tests
+
+on:
+  pull_request:
+  push:
+    branches: master
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install tox
+        run: python -m pip install tox tox-gh-actions
+      - name: Run tox
+        run: tox
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install tox
+        run: python -m pip install tox
+      - name: Run tox
+        run: tox -e lint

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sentry-dramatiq
 
-[![Travis CI build status (Linux)](https://travis-ci.org/jmagnusson/sentry-dramatiq.svg?branch=master)](https://travis-ci.org/jmagnusson/sentry-dramatiq)
+![Github Actions Status](https://github.com/jacobsvante/sentry-dramatiq/actions/workflows/tests.yml/badge.svg)
 [![PyPI version](https://img.shields.io/pypi/v/sentry-dramatiq.svg)](https://pypi.python.org/pypi/sentry-dramatiq/)
 [![License](https://img.shields.io/pypi/l/sentry-dramatiq.svg)](https://pypi.python.org/pypi/sentry-dramatiq/)
 [![Available as wheel](https://img.shields.io/pypi/wheel/sentry-dramatiq.svg)](https://pypi.python.org/pypi/sentry-dramatiq/)

--- a/sentry_dramatiq/__init__.py
+++ b/sentry_dramatiq/__init__.py
@@ -24,8 +24,7 @@ class DramatiqIntegration(Integration):
     identifier = "dramatiq"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         _patch_dramatiq_broker()
 
 
@@ -117,11 +116,8 @@ class SentryMiddleware(Middleware):
             message._scope_manager.__exit__(None, None, None)
 
 
-def _make_message_event_processor(message, integration):
-    # type: (Message, DramatiqIntegration) -> Callable
-
-    def inner(event, hint):
-        # type: (Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
+def _make_message_event_processor(message: Message, integration: DramatiqIntegration) -> Callable:
+    def inner(event: Dict[str, Any], hint: Dict[str, Any]) -> Dict[str, Any]:
         with capture_internal_exceptions():
             DramatiqMessageExtractor(message).extract_into_event(event)
 
@@ -131,21 +127,18 @@ def _make_message_event_processor(message, integration):
 
 
 class DramatiqMessageExtractor(object):
-    def __init__(self, message):
-        # type: (Message) -> None
+    def __init__(self, message: Message) -> None:
         self.message_data = dict(message.asdict())
 
-    def content_length(self):
-        # type: () -> int
+    def content_length(self) -> int:
         return len(json.dumps(self.message_data))
 
-    def extract_into_event(self, event):
-        # type: (Dict[str, Any]) -> None
+    def extract_into_event(self, event: Dict[str, Any]) -> None:
         client = Hub.current.client
         if client is None:
             return
 
-        data = None  # type: Optional[Union[AnnotatedValue, Dict[str, Any]]]
+        data: Optional[Union[AnnotatedValue, Dict[str, Any]]] = None
 
         content_length = self.content_length()
         contexts = event.setdefault("contexts", {})

--- a/sentry_dramatiq/__init__.py
+++ b/sentry_dramatiq/__init__.py
@@ -2,15 +2,15 @@ import json
 from typing import Any, Callable, Dict, Optional, Union
 
 from dramatiq.broker import Broker
+from dramatiq.errors import Retry
 from dramatiq.message import Message
 from dramatiq.middleware import Middleware, default_middleware
-from dramatiq.errors import Retry
 from sentry_sdk import Hub
 from sentry_sdk.integrations import Integration
 from sentry_sdk.utils import (
     AnnotatedValue,
     capture_internal_exceptions,
-    event_from_exception,
+    event_from_exception
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -34,10 +34,11 @@ setup_kwargs = dict(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,16 +5,16 @@
 
 [tox]
 envlist =
-    py35,py36,py37,py38,py39,py310,py311
+    lint
 
     # === Dramatiq 1.9 ===
-    {py35,py36,py37,py38}-dramatiq-1.9
+    {py37,py38}-dramatiq-1.9
 
     # === Dramatiq 1.11 ===
-    {py35,py36,py37,py38,py39,py310}-dramatiq-1.11
+    {py37,py38,py39,py310}-dramatiq-1.11
 
     # === Dramatiq 1.13 ===
-    {py36,py37,py38,py39,py310}-dramatiq-1.13
+    {py37,py38,py39,py310}-dramatiq-1.13
 
     # === Dramatiq 1.14 ===
     {py37,py38,py39,py310,py311}-dramatiq-1.14
@@ -22,14 +22,23 @@ envlist =
     # === Dramatiq dev ===
     {py37,py38,py39,py310,py311}-dramatiq-dev
 
+[gh-actions]
+python =
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
+    3.11: py311
+
 [testenv]
 commands =
     coverage run --source=sentry_dramatiq -m pytest
 deps =
     .[test]
-    dramatiq-1.3: dramatiq>=1.3,<1.4
-    dramatiq-1.4: dramatiq>=1.4,<1.5
-    dramatiq-1.7: dramatiq>=1.7,<1.8
+    dramatiq-1.9: dramatiq>=1.9,<1.10
+    dramatiq-1.11: dramatiq>=1.11,<1.12
+    dramatiq-1.13: dramatiq>=1.12,<1.13
+    dramatiq-1.14: dramatiq>=1.13,<1.14
     dramatiq-dev: git+https://github.com/Bogdanp/dramatiq#egg=dramatiq
 
 [testenv:lint]
@@ -41,6 +50,7 @@ deps =
 
 [flake8]
 ignore =
+    F401,
     E501,
     E711,
     E712,

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ deps =
 [testenv:lint]
 commands =
     flake8 sentry_dramatiq tests
-    isort --recursive --diff sentry_dramatiq tests
+    isort --diff sentry_dramatiq tests
 deps =
     .[cli,test]
 


### PR DESCRIPTION
This PR

- adds Github action tests
- fixes isort issue it found (recursive is deprecated)
- removed `# type:` style type hints as it doesn't support Python 2 anymore
- removes Python 3.5 and 3.6 support as those are long deprecated and this way less tests need to be run

The image should be okay after the merge, it works on my fork ![](https://github.com/kviktor/sentry-dramatiq/actions/workflows/tests.yml/badge.svg)

Seems like a test rakes around 5 minutes of total runtime https://github.com/kviktor/sentry-dramatiq/actions/runs/4908581722/usage?pr=1 